### PR TITLE
Use explicit C11 atomic wrappers with relaxed defaults

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -58,7 +58,7 @@
 #include "pmix.h"
 
 /* for use when we don't have a PMIx that supports CID generation */
-opal_atomic_int64_t ompi_comm_next_base_cid = 1;
+opal_atomic_int64_t ompi_comm_next_base_cid = OPAL_ATOMIC_INIT(1);
 
 /* A macro comparing two CIDs */
 #define OMPI_COMM_CID_IS_LOWER(comm1,comm2) ( ((comm1)->c_index < (comm2)->c_index)? 1:0)

--- a/ompi/communicator/comm_request.c
+++ b/ompi/communicator/comm_request.c
@@ -18,6 +18,7 @@
  */
 
 #include "comm_request.h"
+#include "opal/sys/atomic.h"
 
 #include "opal/class/opal_free_list.h"
 #include "opal/include/opal/sys/atomic.h"
@@ -109,7 +110,7 @@ int ompi_comm_request_schedule_append_w_flags(ompi_comm_request_t *request, ompi
 static int ompi_comm_request_progress (void)
 {
     ompi_comm_request_t *request, *next;
-    static opal_atomic_int32_t progressing = 0;
+    static opal_atomic_int32_t progressing = OPAL_ATOMIC_INIT(0);
     int completed = 0;
 
     /* don't allow re-entry */
@@ -175,7 +176,7 @@ static int ompi_comm_request_progress (void)
     }
 
     opal_mutex_unlock (&ompi_comm_request_mutex);
-    progressing = 0;
+    opal_atomic_store_32(&progressing, 0);
 
     return completed;
 }

--- a/ompi/communicator/ft/comm_ft_detector.c
+++ b/ompi/communicator/ft/comm_ft_detector.c
@@ -18,6 +18,7 @@
 #include "opal/mca/threads/threads.h"
 
 #include "ompi/runtime/params.h"
+#include "opal/sys/atomic.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/bml/bml.h"
@@ -94,7 +95,7 @@ static opal_event_base_t* fd_event_base = NULL;
 static void fd_event_cb(int fd, short flags, void* pdetector);
 
 static bool comm_detector_use_thread = false;
-static opal_atomic_int32_t fd_thread_active = 0;
+static opal_atomic_int32_t fd_thread_active = OPAL_ATOMIC_INIT(0);
 static opal_thread_t fd_thread;
 static void* fd_progress(opal_object_t* obj);
 
@@ -168,8 +169,9 @@ int ompi_comm_failure_detector_init(void) {
         fd_thread.t_arg = NULL;
         ret = opal_thread_start(&fd_thread);
         if( OPAL_SUCCESS != ret ) goto cleanup;
-        while( 0 == fd_thread_active ); /* wait for the fd thread initialization */
-        if( 0 > fd_thread_active ) goto cleanup;
+        while (0 == opal_atomic_load_32(&fd_thread_active)) { /* wait for the fd thread initialization */
+        }
+        if (0 > opal_atomic_load_32(&fd_thread_active)) goto cleanup;
     }
 
     return OMPI_SUCCESS;
@@ -218,18 +220,19 @@ int ompi_comm_failure_detector_finalize(void) {
 #endif
         while( observing == detector->hb_observing ) {
             /* If observed process changed, recheck if local*/
-            if( !(0 < fd_thread_active) )
+            if (!(0 < opal_atomic_load_32(&fd_thread_active)))
             {
                 opal_progress();
             }
         }
     }
 
-    if( 0 < fd_thread_active ) {
+    if (0 < opal_atomic_load_32(&fd_thread_active)) {
         void* tret;
         /* this is not a race condition. Accesses are serialized, we use the
          * atomic for the mfence part of it. */
-        OPAL_THREAD_ADD_FETCH32(&fd_thread_active, -fd_thread_active);
+        int32_t active = opal_atomic_load_32(&fd_thread_active);
+        OPAL_THREAD_ADD_FETCH32(&fd_thread_active, -active);
         opal_event_base_loopbreak(fd_event_base);
         opal_thread_join(&fd_thread, &tret);
     }
@@ -587,9 +590,10 @@ void* fd_progress(opal_object_t* obj) {
         return OPAL_THREAD_CANCELLED;
     }
     OPAL_THREAD_ADD_FETCH32(&fd_thread_active, 1);
-    while( 1 == fd_thread_active ); /* wait for init stage 2: start_detector */
+    while (1 == opal_atomic_load_32(&fd_thread_active)) { /* wait for init stage 2: start_detector */
+    }
     ret = MCA_PML_CALL(irecv(NULL, 0, MPI_BYTE, 0, MCA_COLL_BASE_TAG_FT_END, &ompi_mpi_comm_self.comm, &req));
-    while( fd_thread_active ) {
+    while (opal_atomic_load_32(&fd_thread_active)) {
         opal_event_loop(fd_event_base, OPAL_EVLOOP_ONCE);
 #if 0
         /* This test disabled because rdma emulation over TCP would not work without

--- a/ompi/communicator/ft/comm_ft_reliable_bcast.c
+++ b/ompi/communicator/ft/comm_ft_reliable_bcast.c
@@ -18,6 +18,7 @@
 #include "ompi/mca/pml/pml.h"
 #include "ompi/mca/bml/bml.h"
 #include "ompi/mca/bml/base/base.h"
+#include "opal/sys/atomic.h"
 #include "ompi/mca/coll/base/base.h"
 #include "ompi/mca/coll/base/coll_tags.h"
 
@@ -208,7 +209,7 @@ static void ompi_comm_rbcast_bml_recv_cb(
          * that we keep receiving messages after we deregistered the type.
          * Any other time, this is indicative of a problem.
          */
-        assert(ompi_mpi_state >= OMPI_MPI_STATE_FINALIZE_STARTED);
+        assert(opal_atomic_load_32(&ompi_mpi_state) >= OMPI_MPI_STATE_FINALIZE_STARTED);
     }
 }
 

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -213,7 +213,7 @@ extern opal_atomic_int32_t ompi_instance_count;
  */
 #define OMPI_ERR_INIT_FINALIZE(name)                                       \
     {                                                                      \
-        if (OPAL_UNLIKELY(0 == ompi_instance_count)) {                     \
+        if (OPAL_UNLIKELY(0 == opal_atomic_load_32(&ompi_instance_count))) { \
             ompi_errhandler_invoke(NULL, NULL, -1,                         \
                                    ompi_errcode_get_mpi_code(MPI_ERR_ARG), \
                                    name);                                  \

--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -47,7 +47,7 @@ int ompi_errhandler_invoke(ompi_errhandler_t *errhandler, void *mpi_object,
     /* If we got no errorhandler, then route the error to the appropriate
      * predefined error handler */
     if (NULL == errhandler) {
-        int32_t state = ompi_mpi_state;
+        int32_t state = opal_atomic_load_32(&ompi_mpi_state);
         if (state >= OMPI_MPI_STATE_INIT_COMPLETED &&
             state < OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) {
             comm = (ompi_mpi_compat_mpi3)? &ompi_mpi_comm_world.comm: &ompi_mpi_comm_self.comm;

--- a/ompi/errhandler/errhandler_predefined.c
+++ b/ompi/errhandler/errhandler_predefined.c
@@ -266,7 +266,7 @@ void ompi_mpi_errors_return_instance_handler (struct ompi_instance_t **instance,
 static void out(char *str, char *arg)
 {
     if (ompi_rte_initialized &&
-        ompi_mpi_state < OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) {
+        opal_atomic_load_32(&ompi_mpi_state) < OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) {
         if (NULL != arg) {
             opal_output(0, str, arg);
         } else {
@@ -400,7 +400,7 @@ static void backend_abort_no_aggregate(int fatal, char *type,
 {
     char *arg;
 
-    int32_t state = ompi_mpi_state;
+    int32_t state = opal_atomic_load_32(&ompi_mpi_state);
     assert(state < OMPI_MPI_STATE_INIT_COMPLETED ||
            state >= OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT);
 

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -90,7 +90,7 @@ enum {
     OMPI_INSTANCE_FINALIZING   = -2,
 };
 
-opal_atomic_int32_t ompi_instance_count = 0;
+opal_atomic_int32_t ompi_instance_count = OPAL_ATOMIC_INIT(0);
 
 static const char *ompi_instance_builtin_psets[] = {
     "mpi://WORLD",

--- a/ompi/mca/coll/hcoll/coll_hcoll_ops.c
+++ b/ompi/mca/coll/hcoll/coll_hcoll_ops.c
@@ -16,13 +16,14 @@
 #include "hcoll/api/hcoll_constants.h"
 #include "coll_hcoll_dtypes.h"
 #include "hcoll/api/hcoll_dte.h"
+#include "opal/sys/atomic.h"
 int mca_coll_hcoll_barrier(struct ompi_communicator_t *comm,
                          mca_coll_base_module_t *module){
     int rc;
     mca_coll_hcoll_module_t *hcoll_module = (mca_coll_hcoll_module_t*)module;
     HCOL_VERBOSE(20,"RUNNING HCOL BARRIER");
 
-    if (OPAL_UNLIKELY(ompi_mpi_state >= OMPI_MPI_STATE_FINALIZE_STARTED)) {
+    if (OPAL_UNLIKELY(opal_atomic_load_32(&ompi_mpi_state) >= OMPI_MPI_STATE_FINALIZE_STARTED)) {
         HCOL_VERBOSE(5, "In finalize, reverting to previous barrier");
         goto orig_barrier;
     }

--- a/ompi/mca/common/monitoring/common_monitoring.c
+++ b/ompi/mca/common/monitoring/common_monitoring.c
@@ -39,7 +39,7 @@
 
 /*** Monitoring specific variables ***/
 /* Keep tracks of how many components are currently using the common part */
-static opal_atomic_int32_t mca_common_monitoring_hold = 0;
+static opal_atomic_int32_t mca_common_monitoring_hold = OPAL_ATOMIC_INIT(0);
 /* Output parameters */
 int mca_common_monitoring_output_stream_id = -1;
 static opal_output_stream_t mca_common_monitoring_output_stream_obj = {

--- a/ompi/mca/common/ompio/common_ompio_buffer.c
+++ b/ompi/mca/common/ompio/common_ompio_buffer.c
@@ -29,13 +29,14 @@
 #include "opal/mca/allocator/base/base.h"
 #include "common_ompio.h"
 #include "common_ompio_buffer.h"
+#include "opal/sys/atomic.h"
 
 
 static opal_mutex_t     mca_common_ompio_buffer_mutex;      /* lock for thread safety */
 static mca_allocator_base_component_t* mca_common_ompio_allocator_component=NULL;
 static mca_allocator_base_module_t* mca_common_ompio_allocator=NULL;  
 
-static opal_atomic_int32_t  mca_common_ompio_buffer_init = 0;
+static opal_atomic_int32_t  mca_common_ompio_buffer_init = OPAL_ATOMIC_INIT(0);
 static int32_t  mca_common_ompio_pagesize=4096;
 static void* mca_common_ompio_buffer_alloc_seg ( void *ctx, size_t *size );
 static void mca_common_ompio_buffer_free_seg ( void *ctx, void *buf );
@@ -145,7 +146,7 @@ void *mca_common_ompio_alloc_buf ( ompio_file_t *fh, size_t bufsize )
 {
     char *tmp=NULL;
 
-    if ( !mca_common_ompio_buffer_init ){
+    if (!opal_atomic_load_32(&mca_common_ompio_buffer_init)){
         mca_common_ompio_buffer_alloc_init ();
     }
     
@@ -159,7 +160,7 @@ void *mca_common_ompio_alloc_buf ( ompio_file_t *fh, size_t bufsize )
 void mca_common_ompio_release_buf ( ompio_file_t *fh, void *buf )
 {
 
-    if ( !mca_common_ompio_buffer_init ){
+    if (!opal_atomic_load_32(&mca_common_ompio_buffer_init)){
         /* Should not happen. You can not release a buf without
         ** having it allocated first. 
         */

--- a/ompi/mca/osc/monitoring/osc_monitoring_module.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_module.h
@@ -17,6 +17,7 @@
 #include "ompi/info/info.h"
 #include "ompi/win/win.h"
 #include "ompi/mca/osc/osc.h"
+#include "opal/sys/atomic.h"
 
 /* Define once and for all the module_template variable name */
 #define OMPI_OSC_MONITORING_MODULE_VARIABLE(template)	\
@@ -50,7 +51,7 @@
     OSC_MONITORING_SET_TEMPLATE_FCT_NAME(template) (ompi_osc_base_module_t*module) \
     {                                                                   \
         /* Define the ompi_osc_monitoring_module_## template ##_init_done variable */ \
-        opal_atomic_int32_t init_done = 0;                              \
+        opal_atomic_int32_t init_done = OPAL_ATOMIC_INIT(0);            \
         /* Define and set the ompi_osc_monitoring_## template           \
          * ##_template variable. The functions recorded here are        \
          * linked to the original functions of the original             \

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -18,6 +18,7 @@
 
 #include "ompi/mca/osc/osc.h"
 #include "ompi/mca/osc/base/base.h"
+#include "opal/sys/atomic.h"
 #include "ompi/mca/osc/base/osc_base_obj_convert.h"
 #include "opal/mca/common/ucx/common_ucx.h"
 
@@ -358,8 +359,8 @@ static int component_finalize(void) {
     }
     opal_common_ucx_wpool_free(mca_osc_ucx_component.wpool);
 
-    assert(opal_common_ucx_ep_counts == 0);
-    assert(opal_common_ucx_unpacked_rkey_counts == 0);
+    assert(opal_atomic_load_64(&opal_common_ucx_ep_counts) == 0);
+    assert(opal_atomic_load_64(&opal_common_ucx_unpacked_rkey_counts) == 0);
     return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/pml/base/pml_base_bsend.c
+++ b/ompi/mca/pml/base/pml_base_bsend.c
@@ -54,7 +54,7 @@ static size_t           mca_pml_bsend_size;       /* adjusted size of user buffe
 static size_t           mca_pml_bsend_count;      /* number of outstanding requests */
 static size_t           mca_pml_bsend_pagesz;     /* mmap page size */
 static int              mca_pml_bsend_pagebits;   /* number of bits in pagesz */
-static opal_atomic_int32_t          mca_pml_bsend_init = 0;
+static opal_atomic_int32_t          mca_pml_bsend_init = OPAL_ATOMIC_INIT(0);
 
 /* defined in pml_base_open.c */
 extern char *ompi_pml_base_bsend_allocator_name;

--- a/ompi/mca/pml/base/pml_base_sendreq.c
+++ b/ompi/mca/pml/base/pml_base_sendreq.c
@@ -54,7 +54,7 @@ static void mca_pml_base_send_request_destruct(mca_pml_base_send_request_t* req)
 #if MPI_VERSION >= 4
 int mca_pml_cancel_send_callback(struct ompi_request_t *request, int flag)
 {
-    static opal_atomic_int32_t send_deprecate_count = 0;
+    static opal_atomic_int32_t send_deprecate_count = OPAL_ATOMIC_INIT(0);
     int32_t val;
 
     val = opal_atomic_add_fetch_32(&send_deprecate_count, 1);

--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -53,6 +53,7 @@
 #include "ompi/errhandler/errhandler.h"
 #include "opal/mca/pmix/pmix-internal.h"
 #include "ompi/runtime/ompi_spc.h"
+#include "opal/sys/atomic.h"
 
 #include "pml_ob1.h"
 #include "pml_ob1_component.h"
@@ -908,7 +909,7 @@ void mca_pml_ob1_error_handler(
      * termination. Lets simply ignore such errors after MPI is not supposed to
      * be operational anyway.
      */
-    if(ompi_mpi_state >= OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) {
+    if (opal_atomic_load_32(&ompi_mpi_state) >= OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) {
         return;
     }
 

--- a/ompi/mca/pml/ob1/pml_ob1_progress.c
+++ b/ompi/mca/pml/ob1/pml_ob1_progress.c
@@ -52,7 +52,7 @@ static inline int mca_pml_ob1_process_pending_accelerator_async_copies(void)
     return count;
 }
 
-static opal_atomic_int32_t mca_pml_ob1_progress_needed = 0;
+static opal_atomic_int32_t mca_pml_ob1_progress_needed = OPAL_ATOMIC_INIT(0);
 int mca_pml_ob1_enable_progress(int32_t count)
 {
     int32_t progress_count = OPAL_ATOMIC_ADD_FETCH32(&mca_pml_ob1_progress_needed, count);

--- a/ompi/mpi/c/finalized.c.in
+++ b/ompi/mpi/c/finalized.c.in
@@ -34,7 +34,7 @@ PROTOTYPE ERROR_CLASS finalized(INT_OUT flag)
 {
     ompi_hook_base_mpi_finalized_top(flag);
 
-    int32_t state = ompi_mpi_state;
+    int32_t state = opal_atomic_load_32(&ompi_mpi_state);
 
     if (MPI_PARAM_CHECK) {
         if (NULL == flag) {

--- a/ompi/mpi/c/get_library_version.c.in
+++ b/ompi/mpi/c/get_library_version.c.in
@@ -48,7 +48,7 @@ PROTOTYPE ERROR_CLASS get_library_version(STRING_OUT version, INT_OUT resultlen)
                (i.e., use a NULL communicator, which will end up at the
                default errhandler, which is abort). */
 
-            int32_t state = ompi_mpi_state;
+            int32_t state = opal_atomic_load_32(&ompi_mpi_state);
             if (state >= OMPI_MPI_STATE_INIT_COMPLETED &&
                 state < OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) {
                 return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG,

--- a/ompi/mpi/c/get_version.c.in
+++ b/ompi/mpi/c/get_version.c.in
@@ -46,7 +46,7 @@ PROTOTYPE ERROR_CLASS get_version(INT_OUT version, INT_OUT subversion)
                (i.e., use a NULL communicator, which will end up at the
                default errhandler, which is abort). */
 
-            int32_t state = ompi_mpi_state;
+            int32_t state = opal_atomic_load_32(&ompi_mpi_state);
             if (state >= OMPI_MPI_STATE_INIT_COMPLETED &&
                 state < OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) {
                 return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_ARG,

--- a/ompi/mpi/c/initialized.c.in
+++ b/ompi/mpi/c/initialized.c.in
@@ -34,7 +34,7 @@ PROTOTYPE ERROR_CLASS initialized(INT_OUT flag)
 {
     ompi_hook_base_mpi_initialized_top(flag);
 
-    int32_t state = ompi_mpi_state;
+    int32_t state = opal_atomic_load_32(&ompi_mpi_state);
 
     if (MPI_PARAM_CHECK) {
         if (NULL == flag) {

--- a/ompi/mpi/tool/finalize.c
+++ b/ompi/mpi/tool/finalize.c
@@ -18,6 +18,7 @@
 #include "ompi/mpi/tool/mpit-internal.h"
 
 #include "ompi/runtime/ompi_info_support.h"
+#include "opal/sys/atomic.h"
 #include "opal/include/opal/sys/atomic.h"
 #include "opal/runtime/opal.h"
 
@@ -40,7 +41,7 @@ int MPI_T_finalize (void)
     if (0 == --ompi_mpit_init_count) {
         (void) ompi_info_close_components ();
 
-        int32_t state = ompi_mpi_state;
+        int32_t state = opal_atomic_load_32(&ompi_mpi_state);
         if ((state < OMPI_MPI_STATE_INIT_COMPLETED ||
              state >= OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) &&
             (NULL != ompi_mpi_main_thread)) {

--- a/ompi/peruse/peruse.c
+++ b/ompi/peruse/peruse.c
@@ -18,6 +18,7 @@
 #include "ompi/peruse/peruse.h"
 #include "ompi/peruse/peruse-internal.h"
 #include "ompi/communicator/communicator.h"
+#include "opal/sys/atomic.h"
 #include "ompi/runtime/params.h"
 
 /*
@@ -65,7 +66,7 @@ const int PERUSE_num_events = (sizeof(PERUSE_events) / sizeof(peruse_event_assoc
 int PERUSE_Init (void)
 {
     if (MPI_PARAM_CHECK) {
-        int32_t state = ompi_mpi_state;
+        int32_t state = opal_atomic_load_32(&ompi_mpi_state);
         if (state < OMPI_MPI_STATE_INIT_COMPLETED ||
             state >= OMPI_MPI_STATE_FINALIZE_STARTED) {
             return PERUSE_ERR_INIT;

--- a/ompi/request/grequestx.c
+++ b/ompi/request/grequestx.c
@@ -28,7 +28,7 @@
 
 static bool requests_initialized = false;
 static opal_list_t requests;
-static opal_atomic_int32_t active_requests = 0;
+static opal_atomic_int32_t active_requests = OPAL_ATOMIC_INIT(0);
 static bool in_progress = false;
 static opal_mutex_t lock = OPAL_MUTEX_STATIC_INIT;
 

--- a/ompi/runtime/ompi_mpi_abort.c
+++ b/ompi/runtime/ompi_mpi_abort.c
@@ -169,7 +169,7 @@ ompi_mpi_abort(struct ompi_communicator_t* comm,
 
     /* If the RTE isn't setup yet/any more, then don't even try
        killing everyone.  Sorry, Charlie... */
-    int32_t state = ompi_mpi_state;
+    int32_t state = opal_atomic_load_32(&ompi_mpi_state);
     if (!ompi_rte_initialized) {
         fprintf(stderr, "[%s:%05d] Local abort %s completed successfully, but am not able to aggregate error messages, and not able to guarantee that all other processes were killed!\n",
                 host, (int) pid,

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -113,7 +113,7 @@ int ompi_mpi_finalize(void)
 
     ompi_hook_base_mpi_finalize_top();
 
-    int32_t state = ompi_mpi_state;
+    int32_t state = opal_atomic_load_32(&ompi_mpi_state);
     if (state < OMPI_MPI_STATE_INIT_COMPLETED ||
         state >= OMPI_MPI_STATE_FINALIZE_STARTED) {
         /* Note that if we're not initialized or already finalized, we

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -125,7 +125,7 @@ const char ompi_version_string[] = OMPI_IDENT_STRING;
  * Global variables and symbols for the MPI layer
  */
 
-opal_atomic_int32_t ompi_mpi_state = OMPI_MPI_STATE_NOT_INITIALIZED;
+opal_atomic_int32_t ompi_mpi_state = OPAL_ATOMIC_INIT(OMPI_MPI_STATE_NOT_INITIALIZED);
 volatile bool ompi_rte_initialized = false;
 
 bool ompi_mpi_thread_multiple = false;
@@ -371,7 +371,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
             // silently return successfully once the initializing
             // thread has completed.
             if (reinit_ok) {
-                while (ompi_mpi_state < OMPI_MPI_STATE_INIT_COMPLETED) {
+                while (opal_atomic_load_32(&ompi_mpi_state) < OMPI_MPI_STATE_INIT_COMPLETED) {
                     usleep(1);
                 }
                 return MPI_SUCCESS;

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -324,6 +324,108 @@ static inline void opal_atomic_unlock(opal_atomic_lock_t *lock);
 
 /**********************************************************************
  *
+ * Atomic load/store
+ *
+ *********************************************************************/
+
+static inline int32_t opal_atomic_load_32(const opal_atomic_int32_t *addr);
+static inline int32_t opal_atomic_load_explicit_32(const opal_atomic_int32_t *addr,
+                                                   opal_memory_order_t order);
+static inline void opal_atomic_store_32(opal_atomic_int32_t *addr, int32_t value);
+static inline void opal_atomic_store_explicit_32(opal_atomic_int32_t *addr, int32_t value,
+                                                 opal_memory_order_t order);
+
+static inline int64_t opal_atomic_load_64(const opal_atomic_int64_t *addr);
+static inline int64_t opal_atomic_load_explicit_64(const opal_atomic_int64_t *addr,
+                                                   opal_memory_order_t order);
+static inline void opal_atomic_store_64(opal_atomic_int64_t *addr, int64_t value);
+static inline void opal_atomic_store_explicit_64(opal_atomic_int64_t *addr, int64_t value,
+                                                 opal_memory_order_t order);
+
+static inline size_t opal_atomic_load_size_t(const opal_atomic_size_t *addr);
+static inline size_t opal_atomic_load_explicit_size_t(const opal_atomic_size_t *addr,
+                                                      opal_memory_order_t order);
+static inline void opal_atomic_store_size_t(opal_atomic_size_t *addr, size_t value);
+static inline void opal_atomic_store_explicit_size_t(opal_atomic_size_t *addr, size_t value,
+                                                     opal_memory_order_t order);
+
+#if OPAL_USE_C11_ATOMICS == 0
+static inline int32_t opal_atomic_load_32(const opal_atomic_int32_t *addr)
+{
+    return *addr;
+}
+
+static inline int32_t opal_atomic_load_explicit_32(const opal_atomic_int32_t *addr,
+                                                   opal_memory_order_t order)
+{
+    (void) order;
+    return *addr;
+}
+
+static inline void opal_atomic_store_32(opal_atomic_int32_t *addr, int32_t value)
+{
+    *addr = value;
+}
+
+static inline void opal_atomic_store_explicit_32(opal_atomic_int32_t *addr, int32_t value,
+                                                 opal_memory_order_t order)
+{
+    (void) order;
+    *addr = value;
+}
+
+static inline int64_t opal_atomic_load_64(const opal_atomic_int64_t *addr)
+{
+    return *addr;
+}
+
+static inline int64_t opal_atomic_load_explicit_64(const opal_atomic_int64_t *addr,
+                                                   opal_memory_order_t order)
+{
+    (void) order;
+    return *addr;
+}
+
+static inline void opal_atomic_store_64(opal_atomic_int64_t *addr, int64_t value)
+{
+    *addr = value;
+}
+
+static inline void opal_atomic_store_explicit_64(opal_atomic_int64_t *addr, int64_t value,
+                                                 opal_memory_order_t order)
+{
+    (void) order;
+    *addr = value;
+}
+
+static inline size_t opal_atomic_load_size_t(const opal_atomic_size_t *addr)
+{
+    return *addr;
+}
+
+static inline size_t opal_atomic_load_explicit_size_t(const opal_atomic_size_t *addr,
+                                                      opal_memory_order_t order)
+{
+    (void) order;
+    return *addr;
+}
+
+static inline void opal_atomic_store_size_t(opal_atomic_size_t *addr, size_t value)
+{
+    *addr = value;
+}
+
+static inline void opal_atomic_store_explicit_size_t(opal_atomic_size_t *addr, size_t value,
+                                                     opal_memory_order_t order)
+{
+    (void) order;
+    *addr = value;
+}
+#endif
+
+
+/**********************************************************************
+ *
  * Atomic math operations
  *
  *********************************************************************/

--- a/opal/include/opal/sys/atomic_stdc.h
+++ b/opal/include/opal/sys/atomic_stdc.h
@@ -67,44 +67,77 @@ static inline void opal_atomic_rmb(void)
 
 /**********************************************************************
  *
+ * Load and store
+ *
+ *********************************************************************/
+
+#    define OPAL_ATOMIC_STDC_DEFINE_LOAD_STORE(bits, type)                                 \
+        static inline type opal_atomic_load_explicit_##bits(const opal_atomic_##type *addr, \
+                                                            opal_memory_order_t order)     \
+        {                                                                                  \
+            return atomic_load_explicit(&addr->v, order);                                  \
+        }                                                                                  \
+        static inline type opal_atomic_load_##bits(const opal_atomic_##type *addr)         \
+        {                                                                                  \
+            return opal_atomic_load_explicit_##bits(addr, OPAL_ATOMIC_ORDER_RELAXED);      \
+        }                                                                                  \
+        static inline void opal_atomic_store_explicit_##bits(opal_atomic_##type *addr,     \
+                                                             type value,                  \
+                                                             opal_memory_order_t order)   \
+        {                                                                                  \
+            atomic_store_explicit(&addr->v, value, order);                                 \
+        }                                                                                  \
+        static inline void opal_atomic_store_##bits(opal_atomic_##type *addr, type value)  \
+        {                                                                                  \
+            opal_atomic_store_explicit_##bits(addr, value, OPAL_ATOMIC_ORDER_RELAXED);     \
+        }
+
+OPAL_ATOMIC_STDC_DEFINE_LOAD_STORE(32, int32_t)
+OPAL_ATOMIC_STDC_DEFINE_LOAD_STORE(64, int64_t)
+OPAL_ATOMIC_STDC_DEFINE_LOAD_STORE(size_t, size_t)
+
+
+/**********************************************************************
+ *
  * Compare and Swap
  *
  *********************************************************************/
 
 #    define opal_atomic_compare_exchange_strong_32(addr, compare, value)                    \
-        atomic_compare_exchange_strong_explicit(addr, compare, value, memory_order_relaxed, \
-                                                memory_order_relaxed)
+        atomic_compare_exchange_strong_explicit(&((addr)->v), compare, value,               \
+                                                memory_order_relaxed, memory_order_relaxed)
 #    define opal_atomic_compare_exchange_strong_acq_32(addr, compare, value)                \
-        atomic_compare_exchange_strong_explicit(addr, compare, value, memory_order_acquire, \
-                                                memory_order_relaxed)
+        atomic_compare_exchange_strong_explicit(&((addr)->v), compare, value,               \
+                                                memory_order_acquire, memory_order_relaxed)
 #    define opal_atomic_compare_exchange_strong_rel_32(addr, compare, value)                \
-        atomic_compare_exchange_strong_explicit(addr, compare, value, memory_order_release, \
-                                                memory_order_relaxed)
+        atomic_compare_exchange_strong_explicit(&((addr)->v), compare, value,               \
+                                                memory_order_release, memory_order_relaxed)
 
 #    define opal_atomic_compare_exchange_strong_64(addr, compare, value)                    \
-        atomic_compare_exchange_strong_explicit(addr, compare, value, memory_order_relaxed, \
-                                                memory_order_relaxed)
+        atomic_compare_exchange_strong_explicit(&((addr)->v), compare, value,               \
+                                                memory_order_relaxed, memory_order_relaxed)
 #    define opal_atomic_compare_exchange_strong_acq_64(addr, compare, value)                \
-        atomic_compare_exchange_strong_explicit(addr, compare, value, memory_order_acquire, \
-                                                memory_order_relaxed)
+        atomic_compare_exchange_strong_explicit(&((addr)->v), compare, value,               \
+                                                memory_order_acquire, memory_order_relaxed)
 #    define opal_atomic_compare_exchange_strong_rel_64(addr, compare, value)                \
-        atomic_compare_exchange_strong_explicit(addr, compare, value, memory_order_release, \
-                                                memory_order_relaxed)
+        atomic_compare_exchange_strong_explicit(&((addr)->v), compare, value,               \
+                                                memory_order_release, memory_order_relaxed)
 
 #    define opal_atomic_compare_exchange_strong_ptr(addr, compare, value)                   \
-        atomic_compare_exchange_strong_explicit(addr, compare, value, memory_order_relaxed, \
-                                                memory_order_relaxed)
+        atomic_compare_exchange_strong_explicit(&((addr)->v), compare, value,               \
+                                                memory_order_relaxed, memory_order_relaxed)
 #    define opal_atomic_compare_exchange_strong_acq_ptr(addr, compare, value)               \
-        atomic_compare_exchange_strong_explicit(addr, compare, value, memory_order_acquire, \
-                                                memory_order_relaxed)
+        atomic_compare_exchange_strong_explicit(&((addr)->v), compare, value,               \
+                                                memory_order_acquire, memory_order_relaxed)
 #    define opal_atomic_compare_exchange_strong_rel_ptr(addr, compare, value)               \
-        atomic_compare_exchange_strong_explicit(addr, compare, value, memory_order_release, \
-                                                memory_order_relaxed)
+        atomic_compare_exchange_strong_explicit(&((addr)->v), compare, value,               \
+                                                memory_order_release, memory_order_relaxed)
 
 #    if OPAL_HAVE_C11_CSWAP_INT128
 
 /* the C11 atomic compare-exchange is lock free so use it */
-#        define opal_atomic_compare_exchange_strong_128 atomic_compare_exchange_strong
+#        define opal_atomic_compare_exchange_strong_128(addr, compare, value) \
+            atomic_compare_exchange_strong(&((addr)->v), compare, value)
 
 #        define OPAL_HAVE_ATOMIC_COMPARE_EXCHANGE_128 1
 
@@ -116,7 +149,7 @@ __opal_attribute_always_inline__ static inline bool
 opal_atomic_compare_exchange_strong_128(opal_atomic_int128_t *addr, opal_int128_t *oldval,
                                         opal_int128_t newval)
 {
-    opal_int128_t prev = __sync_val_compare_and_swap(addr, *oldval, newval);
+    opal_int128_t prev = __sync_val_compare_and_swap(&addr->v, *oldval, newval);
     bool ret = prev == *oldval;
     *oldval = prev;
     return ret;
@@ -138,11 +171,11 @@ opal_atomic_compare_exchange_strong_128(opal_atomic_int128_t *addr, opal_int128_
  *********************************************************************/
 
 #    define opal_atomic_swap_32(addr, value) \
-        atomic_exchange_explicit((_Atomic unsigned int *) addr, value, memory_order_relaxed)
+        atomic_exchange_explicit(&((addr)->v), value, memory_order_relaxed)
 #    define opal_atomic_swap_64(addr, value) \
-        atomic_exchange_explicit((_Atomic unsigned long *) addr, value, memory_order_relaxed)
+        atomic_exchange_explicit(&((addr)->v), value, memory_order_relaxed)
 #    define opal_atomic_swap_ptr(addr, value) \
-        atomic_exchange_explicit((_Atomic unsigned long *) addr, value, memory_order_relaxed)
+        atomic_exchange_explicit(&((addr)->v), value, memory_order_relaxed)
 
 
 /**********************************************************************
@@ -184,12 +217,12 @@ static inline void opal_atomic_unlock(opal_atomic_lock_t *lock)
 #    define OPAL_ATOMIC_STDC_DEFINE_FETCH_OP(op, bits, type, operator)                             \
         static inline type opal_atomic_fetch_##op##_##bits(opal_atomic_##type *addr, type value)   \
         {                                                                                          \
-            return atomic_fetch_##op##_explicit(addr, value, memory_order_relaxed);                \
+            return atomic_fetch_##op##_explicit(&addr->v, value, memory_order_relaxed);            \
         }                                                                                          \
                                                                                                    \
         static inline type opal_atomic_##op##_fetch_##bits(opal_atomic_##type *addr, type value)   \
         {                                                                                          \
-            return atomic_fetch_##op##_explicit(addr, value, memory_order_relaxed) operator value; \
+            return atomic_fetch_##op##_explicit(&addr->v, value, memory_order_relaxed) operator value; \
         }
 
 OPAL_ATOMIC_STDC_DEFINE_FETCH_OP(add, 32, int32_t, +)
@@ -208,7 +241,7 @@ OPAL_ATOMIC_STDC_DEFINE_FETCH_OP(add, size_t, size_t, +)
 OPAL_ATOMIC_STDC_DEFINE_FETCH_OP(sub, size_t, size_t, -)
 
 #    define opal_atomic_add(addr, value) \
-        (void) atomic_fetch_add_explicit(addr, value, memory_order_relaxed)
+        (void) atomic_fetch_add_explicit(&((addr)->v), value, memory_order_relaxed)
 
 #include "opal/sys/atomic_impl_minmax_math.h"
 

--- a/opal/include/opal_stdatomic.h
+++ b/opal/include/opal_stdatomic.h
@@ -38,22 +38,32 @@ enum { OPAL_ATOMIC_LOCK_UNLOCKED = 0,
 
 #    define OPAL_ATOMIC_LOCK_INIT OPAL_ATOMIC_LOCK_UNLOCKED
 
+#    define OPAL_ATOMIC_INIT(v) (v)
+
+typedef enum {
+    OPAL_ATOMIC_ORDER_RELAXED,
+    OPAL_ATOMIC_ORDER_ACQUIRE,
+    OPAL_ATOMIC_ORDER_RELEASE,
+    OPAL_ATOMIC_ORDER_ACQ_REL,
+    OPAL_ATOMIC_ORDER_SEQ_CST
+} opal_memory_order_t;
+
 #else /* OPAL_USE_C11_ATOMICS == 0 */
 
 #    include <stdatomic.h>
 
-typedef atomic_int opal_atomic_int_t;
-typedef atomic_long opal_atomic_long_t;
+typedef struct { _Atomic int v; } opal_atomic_int_t;
+typedef struct { _Atomic long v; } opal_atomic_long_t;
 
-typedef _Atomic int32_t opal_atomic_int32_t;
-typedef _Atomic uint32_t opal_atomic_uint32_t;
-typedef _Atomic int64_t opal_atomic_int64_t;
-typedef _Atomic uint64_t opal_atomic_uint64_t;
+typedef struct { _Atomic int32_t v; } opal_atomic_int32_t;
+typedef struct { _Atomic uint32_t v; } opal_atomic_uint32_t;
+typedef struct { _Atomic int64_t v; } opal_atomic_int64_t;
+typedef struct { _Atomic uint64_t v; } opal_atomic_uint64_t;
 
-typedef _Atomic size_t opal_atomic_size_t;
-typedef _Atomic ssize_t opal_atomic_ssize_t;
-typedef _Atomic intptr_t opal_atomic_intptr_t;
-typedef _Atomic uintptr_t opal_atomic_uintptr_t;
+typedef struct { _Atomic size_t v; } opal_atomic_size_t;
+typedef struct { _Atomic ssize_t v; } opal_atomic_ssize_t;
+typedef struct { _Atomic intptr_t v; } opal_atomic_intptr_t;
+typedef struct { _Atomic uintptr_t v; } opal_atomic_uintptr_t;
 
 typedef atomic_flag opal_atomic_lock_t;
 
@@ -62,17 +72,28 @@ typedef atomic_flag opal_atomic_lock_t;
 
 #    define OPAL_ATOMIC_LOCK_INIT ATOMIC_FLAG_INIT
 
+#    define OPAL_ATOMIC_INIT(v) { .v = (v) }
+
+typedef memory_order opal_memory_order_t;
+#    define OPAL_ATOMIC_ORDER_RELAXED memory_order_relaxed
+#    define OPAL_ATOMIC_ORDER_ACQUIRE memory_order_acquire
+#    define OPAL_ATOMIC_ORDER_RELEASE memory_order_release
+#    define OPAL_ATOMIC_ORDER_ACQ_REL memory_order_acq_rel
+#    define OPAL_ATOMIC_ORDER_SEQ_CST memory_order_seq_cst
+
 #    endif /* OPAL_USE_C11_ATOMICS == 0 */
 
 #    if HAVE_OPAL_INT128_T
 
 #        if OPAL_USE_C11_ATOMICS && OPAL_HAVE_C11_CSWAP_INT128
 
-typedef _Atomic opal_int128_t opal_atomic_int128_t;
+typedef struct { _Atomic opal_int128_t v; } opal_atomic_int128_t;
 
 #        else
 
-typedef volatile opal_int128_t opal_atomic_int128_t __opal_attribute_aligned__(16);
+typedef struct {
+    volatile opal_int128_t v;
+} opal_atomic_int128_t __opal_attribute_aligned__(16);
 
 #        endif
 

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -549,7 +549,7 @@ static void mca_btl_sm_progress_endpoints(void)
 
 static int mca_btl_sm_component_progress(void)
 {
-    static opal_atomic_int32_t lock = 0;
+    static opal_atomic_int32_t lock = OPAL_ATOMIC_INIT(0);
     int count = 0;
 
     if (opal_using_threads()) {

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -32,8 +32,8 @@ __thread int initialized = 0;
 #endif
 
 bool opal_common_ucx_thread_enabled = false;
-opal_atomic_int64_t opal_common_ucx_ep_counts = 0;
-opal_atomic_int64_t opal_common_ucx_unpacked_rkey_counts = 0;
+opal_atomic_int64_t opal_common_ucx_ep_counts = OPAL_ATOMIC_INIT(0);
+opal_atomic_int64_t opal_common_ucx_unpacked_rkey_counts = OPAL_ATOMIC_INIT(0);
 
 static _ctx_record_t *_tlocal_add_ctx_rec(opal_common_ucx_ctx_t *ctx);
 static inline _ctx_record_t *_tlocal_get_ctx_rec(opal_tsd_tracked_key_t tls_key);

--- a/opal/mca/threads/base/wait_sync.c
+++ b/opal/mca/threads/base/wait_sync.c
@@ -47,7 +47,7 @@ void opal_threads_base_wait_sync_global_wakeup_mt(int status)
     opal_mutex_unlock(&wait_sync_lock);
 }
 
-static opal_atomic_int32_t num_thread_in_progress = 0;
+static opal_atomic_int32_t num_thread_in_progress = OPAL_ATOMIC_INIT(0);
 
 #define WAIT_SYNC_PASS_OWNERSHIP(who)                        \
     do {                                                     \

--- a/opal/runtime/opal_progress.c
+++ b/opal/runtime/opal_progress.c
@@ -36,6 +36,7 @@
 #include "opal/runtime/opal_progress.h"
 #include "opal/util/event.h"
 #include "opal/util/output.h"
+#include "opal/sys/atomic.h"
 
 #define OPAL_PROGRESS_USE_TIMERS       (OPAL_TIMER_CYCLE_SUPPORTED || OPAL_TIMER_USEC_SUPPORTED)
 #define OPAL_PROGRESS_ONLY_USEC_NATIVE (OPAL_TIMER_USEC_NATIVE && !OPAL_TIMER_CYCLE_NATIVE)
@@ -72,13 +73,13 @@ static opal_timer_t event_progress_last_time = 0;
 static opal_timer_t event_progress_delta = 0;
 #else
 /* current count down until we tick the event library */
-static opal_atomic_int32_t event_progress_counter = 0;
+static opal_atomic_int32_t event_progress_counter = OPAL_ATOMIC_INIT(0);
 /* reset value for counter when it hits 0 */
 static int32_t event_progress_delta = 0;
 #endif
 /* users of the event library from MPI cause the tick rate to
    be every time */
-static opal_atomic_int32_t num_event_users = 0;
+static opal_atomic_int32_t num_event_users = OPAL_ATOMIC_INIT(0);
 
 #if OPAL_ENABLE_DEBUG
 static int debug_output = -1;
@@ -159,7 +160,8 @@ int opal_progress_init(void)
         (debug_output, "progress: initialized event flag to: %x", opal_progress_event_flag));
     OPAL_OUTPUT((debug_output, "progress: initialized yield_when_idle to: %s",
                  opal_progress_yield_when_idle ? "true" : "false"));
-    OPAL_OUTPUT((debug_output, "progress: initialized num users to: %d", num_event_users));
+    OPAL_OUTPUT((debug_output, "progress: initialized num users to: %d",
+                 opal_atomic_load_32(&num_event_users)));
     OPAL_OUTPUT(
         (debug_output, "progress: initialized poll rate to: %ld", (long) event_progress_delta));
 
@@ -170,7 +172,7 @@ int opal_progress_init(void)
 
 static int opal_progress_events(void)
 {
-    static opal_atomic_int32_t lock = 0;
+    static opal_atomic_int32_t lock = OPAL_ATOMIC_INIT(0);
     int events = 0;
 
     if (opal_progress_event_flag != 0 && !OPAL_THREAD_SWAP_32(&lock, 1)) {
@@ -183,7 +185,9 @@ static int opal_progress_events(void)
         /* trip the event library if we've reached our tick rate and we are
            enabled */
         if (now - event_progress_last_time > event_progress_delta) {
-            event_progress_last_time = (num_event_users > 0) ? now - event_progress_delta : now;
+            event_progress_last_time = (opal_atomic_load_32(&num_event_users) > 0)
+                                           ? now - event_progress_delta
+                                           : now;
 
             events += opal_event_loop(opal_sync_event_base, opal_progress_event_flag);
         }
@@ -192,7 +196,8 @@ static int opal_progress_events(void)
         /* trip the event library if we've reached our tick rate and we are
            enabled */
         if (OPAL_THREAD_ADD_FETCH32(&event_progress_counter, -1) <= 0) {
-            event_progress_counter = (num_event_users > 0) ? 0 : event_progress_delta;
+            opal_atomic_store_32(&event_progress_counter,
+                                 (opal_atomic_load_32(&num_event_users) > 0) ? 0 : event_progress_delta);
             events += opal_event_loop(opal_sync_event_base, opal_progress_event_flag);
         }
 #endif /* OPAL_PROGRESS_USE_TIMERS */
@@ -236,7 +241,7 @@ int opal_progress(void)
         }
 
         opal_progress_events();
-    } else if (num_event_users > 0) {
+    } else if (opal_atomic_load_32(&num_event_users) > 0) {
         opal_progress_events();
     }
 
@@ -280,7 +285,7 @@ void opal_progress_event_users_increment(void)
     event_progress_last_time -= event_progress_delta;
 #else
     /* always reset the tick rate - can't hurt */
-    event_progress_counter = 0;
+    opal_atomic_store_32(&event_progress_counter, 0);
 #endif
 }
 
@@ -298,7 +303,7 @@ void opal_progress_event_users_decrement(void)
 #if !OPAL_PROGRESS_USE_TIMERS
     /* start now in delaying if it's easy */
     if (val >= 0) {
-        event_progress_counter = event_progress_delta;
+        opal_atomic_store_32(&event_progress_counter, event_progress_delta);
     }
 #endif
 }
@@ -326,7 +331,8 @@ void opal_progress_set_event_poll_rate(int polltime)
     event_progress_last_time = opal_timer_base_get_cycles();
 #    endif
 #else
-    event_progress_counter = event_progress_delta = 0;
+    opal_atomic_store_32(&event_progress_counter, 0);
+    event_progress_delta = 0;
 #endif
 
     if (polltime == 0) {

--- a/oshmem/runtime/oshmem_shmem_finalize.c
+++ b/oshmem/runtime/oshmem_shmem_finalize.c
@@ -75,7 +75,7 @@ int oshmem_shmem_finalize(void)
     /* Note: ompi_mpi_state is set atomically in ompi_mpi_init() and
        ompi_mpi_finalize().  Those 2 functions have the appropriate
        memory barriers such that we don't need one here. */
-    int32_t state = ompi_mpi_state;
+    int32_t state = opal_atomic_load_32(&ompi_mpi_state);
     if ((OSHMEM_SUCCESS == ret) &&
         (state >= OMPI_MPI_STATE_INIT_COMPLETED &&
          state < OMPI_MPI_STATE_FINALIZE_PAST_COMM_SELF_DESTRUCT) &&

--- a/test/asm/atomic_cmpset.c
+++ b/test/asm/atomic_cmpset.c
@@ -44,13 +44,13 @@ int nreps = 100;
 int nthreads = 2;
 int enable_verbose = 0;
 
-opal_atomic_int32_t vol32 = 0;
-opal_atomic_int32_t val32 = 0;
+opal_atomic_int32_t vol32 = OPAL_ATOMIC_INIT(0);
+opal_atomic_int32_t val32 = OPAL_ATOMIC_INIT(0);
 int32_t old32 = 0;
 int32_t new32 = 0;
 
-opal_atomic_int64_t vol64 = 0;
-opal_atomic_int64_t val64 = 0;
+opal_atomic_int64_t vol64 = OPAL_ATOMIC_INIT(0);
+opal_atomic_int64_t val64 = OPAL_ATOMIC_INIT(0);
 int64_t old64 = 0;
 int64_t new64 = 0;
 

--- a/test/asm/atomic_math.c
+++ b/test/asm/atomic_math.c
@@ -32,8 +32,8 @@
 
 #define TEST_REPS 500
 
-opal_atomic_int32_t val32 = 0;
-opal_atomic_int64_t val64 = 0;
+opal_atomic_int32_t val32 = OPAL_ATOMIC_INIT(0);
+opal_atomic_int64_t val64 = OPAL_ATOMIC_INIT(0);
 opal_atomic_int_t valint = 0;
 
 static void *atomic_math_test(void *arg)

--- a/test/threads/opal_atomic_thread_bench.c
+++ b/test/threads/opal_atomic_thread_bench.c
@@ -80,8 +80,8 @@ int pthread_barrier_wait(pthread_barrier_t *barrier)
 }
 #endif
 
-static opal_atomic_int64_t var_64 = 0;
-static opal_atomic_int32_t var_32 = 0;
+static opal_atomic_int64_t var_64 = OPAL_ATOMIC_INIT(0);
+static opal_atomic_int32_t var_32 = OPAL_ATOMIC_INIT(0);
 static pthread_barrier_t barrier;
 
 #if !defined(timersub)


### PR DESCRIPTION
## Summary
- Wrap C11 `_Atomic` types in structs to prevent direct access and define memory order enums
- Add explicit load/store helpers with optional memory order argument, defaulting to relaxed
- Update code to use new `opal_atomic_load`/`store` APIs and initialize atomics via `OPAL_ATOMIC_INIT`

## Testing
- `./autogen.pl` *(fails: could not find a recent enough copy of libtool)*

------
https://chatgpt.com/codex/tasks/task_b_68a372de25408326b0cd9e6f9e0147a4