### PR TITLE
Refactor atomics to enforce API-based access with relaxed load/store

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -58,7 +58,7 @@
 #include "pmix.h"
 
 /* for use when we don't have a PMIx that supports CID generation */
-opal_atomic_int64_t ompi_comm_next_base_cid = 1;
+opal_atomic_int64_t ompi_comm_next_base_cid = OPAL_ATOMIC_VAR_INIT(1);
 
 /* A macro comparing two CIDs */
 #define OMPI_COMM_CID_IS_LOWER(comm1,comm2) ( ((comm1)->c_index < (comm2)->c_index)? 1:0)

--- a/ompi/communicator/comm_request.c
+++ b/ompi/communicator/comm_request.c
@@ -109,7 +109,7 @@ int ompi_comm_request_schedule_append_w_flags(ompi_comm_request_t *request, ompi
 static int ompi_comm_request_progress (void)
 {
     ompi_comm_request_t *request, *next;
-    static opal_atomic_int32_t progressing = 0;
+    static opal_atomic_int32_t progressing = OPAL_ATOMIC_VAR_INIT(0);
     int completed = 0;
 
     /* don't allow re-entry */
@@ -175,7 +175,7 @@ static int ompi_comm_request_progress (void)
     }
 
     opal_mutex_unlock (&ompi_comm_request_mutex);
-    progressing = 0;
+    opal_atomic_store(&progressing, 0);
 
     return completed;
 }

--- a/ompi/errhandler/errhandler.h
+++ b/ompi/errhandler/errhandler.h
@@ -213,7 +213,7 @@ extern opal_atomic_int32_t ompi_instance_count;
  */
 #define OMPI_ERR_INIT_FINALIZE(name)                                       \
     {                                                                      \
-        if (OPAL_UNLIKELY(0 == ompi_instance_count)) {                     \
+        if (OPAL_UNLIKELY(0 == opal_atomic_load(&ompi_instance_count))) {   \
             ompi_errhandler_invoke(NULL, NULL, -1,                         \
                                    ompi_errcode_get_mpi_code(MPI_ERR_ARG), \
                                    name);                                  \

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -90,7 +90,7 @@ enum {
     OMPI_INSTANCE_FINALIZING   = -2,
 };
 
-opal_atomic_int32_t ompi_instance_count = 0;
+opal_atomic_int32_t ompi_instance_count = OPAL_ATOMIC_VAR_INIT(0);
 
 static const char *ompi_instance_builtin_psets[] = {
     "mpi://WORLD",

--- a/ompi/mca/coll/xhc/coll_xhc_intrinsic.h
+++ b/ompi/mca/coll/xhc/coll_xhc_intrinsic.h
@@ -43,11 +43,13 @@ typedef size_t __attribute__((aligned(SIZEOF_SIZE_T))) xf_size_t;
 // https://github.com/open-mpi/ompi/issues/9722
 
 #if OPAL_USE_GCC_BUILTIN_ATOMICS || OPAL_USE_C11_ATOMICS
-    #define xhc_atomic_load_int(addr) __atomic_load_n(addr, __ATOMIC_RELAXED)
-    #define xhc_atomic_store_int(addr, val) __atomic_store_n(addr, val, __ATOMIC_RELAXED)
+    #define xhc_atomic_load_int(addr)  opal_atomic_load((opal_atomic_int_t *)(addr))
+    #define xhc_atomic_store_int(addr, val)                                           \
+        opal_atomic_store((opal_atomic_int_t *)(addr), (val))
 
-    #define xhc_atomic_load_size_t(addr) __atomic_load_n(addr, __ATOMIC_RELAXED)
-    #define xhc_atomic_store_size_t(addr, val) __atomic_store_n(addr, val, __ATOMIC_RELAXED)
+    #define xhc_atomic_load_size_t(addr) opal_atomic_load((opal_atomic_size_t *)(addr))
+    #define xhc_atomic_store_size_t(addr, val)                                        \
+        opal_atomic_store((opal_atomic_size_t *)(addr), (val))
 #else
     #define xhc_atomic_load_int(addr) (*(addr))
     #define xhc_atomic_store_int(addr, val) (*(addr) = (val))

--- a/ompi/mca/common/monitoring/common_monitoring.c
+++ b/ompi/mca/common/monitoring/common_monitoring.c
@@ -39,7 +39,7 @@
 
 /*** Monitoring specific variables ***/
 /* Keep tracks of how many components are currently using the common part */
-static opal_atomic_int32_t mca_common_monitoring_hold = 0;
+static opal_atomic_int32_t mca_common_monitoring_hold = OPAL_ATOMIC_VAR_INIT(0);
 /* Output parameters */
 int mca_common_monitoring_output_stream_id = -1;
 static opal_output_stream_t mca_common_monitoring_output_stream_obj = {

--- a/ompi/mca/common/ompio/common_ompio_buffer.c
+++ b/ompi/mca/common/ompio/common_ompio_buffer.c
@@ -35,7 +35,7 @@ static opal_mutex_t     mca_common_ompio_buffer_mutex;      /* lock for thread s
 static mca_allocator_base_component_t* mca_common_ompio_allocator_component=NULL;
 static mca_allocator_base_module_t* mca_common_ompio_allocator=NULL;  
 
-static opal_atomic_int32_t  mca_common_ompio_buffer_init = 0;
+static opal_atomic_int32_t  mca_common_ompio_buffer_init = OPAL_ATOMIC_VAR_INIT(0);
 static int32_t  mca_common_ompio_pagesize=4096;
 static void* mca_common_ompio_buffer_alloc_seg ( void *ctx, size_t *size );
 static void mca_common_ompio_buffer_free_seg ( void *ctx, void *buf );
@@ -145,7 +145,7 @@ void *mca_common_ompio_alloc_buf ( ompio_file_t *fh, size_t bufsize )
 {
     char *tmp=NULL;
 
-    if ( !mca_common_ompio_buffer_init ){
+    if ( !opal_atomic_load(&mca_common_ompio_buffer_init) ){
         mca_common_ompio_buffer_alloc_init ();
     }
     
@@ -159,7 +159,7 @@ void *mca_common_ompio_alloc_buf ( ompio_file_t *fh, size_t bufsize )
 void mca_common_ompio_release_buf ( ompio_file_t *fh, void *buf )
 {
 
-    if ( !mca_common_ompio_buffer_init ){
+    if ( !opal_atomic_load(&mca_common_ompio_buffer_init) ){
         /* Should not happen. You can not release a buf without
         ** having it allocated first. 
         */

--- a/ompi/mca/osc/monitoring/osc_monitoring_module.h
+++ b/ompi/mca/osc/monitoring/osc_monitoring_module.h
@@ -50,7 +50,7 @@
     OSC_MONITORING_SET_TEMPLATE_FCT_NAME(template) (ompi_osc_base_module_t*module) \
     {                                                                   \
         /* Define the ompi_osc_monitoring_module_## template ##_init_done variable */ \
-        opal_atomic_int32_t init_done = 0;                              \
+        opal_atomic_int32_t init_done = OPAL_ATOMIC_VAR_INIT(0);        \
         /* Define and set the ompi_osc_monitoring_## template           \
          * ##_template variable. The functions recorded here are        \
          * linked to the original functions of the original             \

--- a/ompi/mca/pml/base/pml_base_bsend.c
+++ b/ompi/mca/pml/base/pml_base_bsend.c
@@ -54,7 +54,7 @@ static size_t           mca_pml_bsend_size;       /* adjusted size of user buffe
 static size_t           mca_pml_bsend_count;      /* number of outstanding requests */
 static size_t           mca_pml_bsend_pagesz;     /* mmap page size */
 static int              mca_pml_bsend_pagebits;   /* number of bits in pagesz */
-static opal_atomic_int32_t          mca_pml_bsend_init = 0;
+static opal_atomic_int32_t          mca_pml_bsend_init = OPAL_ATOMIC_VAR_INIT(0);
 
 /* defined in pml_base_open.c */
 extern char *ompi_pml_base_bsend_allocator_name;

--- a/ompi/mca/pml/base/pml_base_sendreq.c
+++ b/ompi/mca/pml/base/pml_base_sendreq.c
@@ -54,7 +54,7 @@ static void mca_pml_base_send_request_destruct(mca_pml_base_send_request_t* req)
 #if MPI_VERSION >= 4
 int mca_pml_cancel_send_callback(struct ompi_request_t *request, int flag)
 {
-    static opal_atomic_int32_t send_deprecate_count = 0;
+    static opal_atomic_int32_t send_deprecate_count = OPAL_ATOMIC_VAR_INIT(0);
     int32_t val;
 
     val = opal_atomic_add_fetch_32(&send_deprecate_count, 1);

--- a/ompi/mca/pml/ob1/pml_ob1_progress.c
+++ b/ompi/mca/pml/ob1/pml_ob1_progress.c
@@ -52,7 +52,7 @@ static inline int mca_pml_ob1_process_pending_accelerator_async_copies(void)
     return count;
 }
 
-static opal_atomic_int32_t mca_pml_ob1_progress_needed = 0;
+static opal_atomic_int32_t mca_pml_ob1_progress_needed = OPAL_ATOMIC_VAR_INIT(0);
 int mca_pml_ob1_enable_progress(int32_t count)
 {
     int32_t progress_count = OPAL_ATOMIC_ADD_FETCH32(&mca_pml_ob1_progress_needed, count);

--- a/ompi/request/grequestx.c
+++ b/ompi/request/grequestx.c
@@ -28,7 +28,7 @@
 
 static bool requests_initialized = false;
 static opal_list_t requests;
-static opal_atomic_int32_t active_requests = 0;
+static opal_atomic_int32_t active_requests = OPAL_ATOMIC_VAR_INIT(0);
 static bool in_progress = false;
 static opal_mutex_t lock = OPAL_MUTEX_STATIC_INIT;
 

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -125,7 +125,7 @@ const char ompi_version_string[] = OMPI_IDENT_STRING;
  * Global variables and symbols for the MPI layer
  */
 
-opal_atomic_int32_t ompi_mpi_state = OMPI_MPI_STATE_NOT_INITIALIZED;
+opal_atomic_int32_t ompi_mpi_state = OPAL_ATOMIC_VAR_INIT(OMPI_MPI_STATE_NOT_INITIALIZED);
 volatile bool ompi_rte_initialized = false;
 
 bool ompi_mpi_thread_multiple = false;
@@ -371,7 +371,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
             // silently return successfully once the initializing
             // thread has completed.
             if (reinit_ok) {
-                while (ompi_mpi_state < OMPI_MPI_STATE_INIT_COMPLETED) {
+                while (opal_atomic_load(&ompi_mpi_state) < OMPI_MPI_STATE_INIT_COMPLETED) {
                     usleep(1);
                 }
                 return MPI_SUCCESS;

--- a/opal/include/opal/sys/atomic.h
+++ b/opal/include/opal/sys/atomic.h
@@ -54,6 +54,20 @@
 #include "opal/opal_portable_platform.h"
 #include "opal_stdatomic.h"
 
+#if OPAL_USE_C11_ATOMICS
+#    define opal_atomic_load(addr) atomic_load_explicit(&((addr)->v), memory_order_relaxed)
+#    define opal_atomic_store(addr, value)                                                      \
+        atomic_store_explicit(&((addr)->v), (value), memory_order_relaxed)
+#    define opal_atomic_load_explicit(addr, order) atomic_load_explicit(&((addr)->v), (order))
+#    define opal_atomic_store_explicit(addr, value, order)                                      \
+        atomic_store_explicit(&((addr)->v), (value), (order))
+#else
+#    define opal_atomic_load(addr) (*(addr))
+#    define opal_atomic_store(addr, value) (*(addr) = (value))
+#    define opal_atomic_load_explicit(addr, order) opal_atomic_load(addr)
+#    define opal_atomic_store_explicit(addr, value, order) opal_atomic_store(addr, value)
+#endif
+
 BEGIN_C_DECLS
 
 /**********************************************************************

--- a/opal/include/opal_stdatomic.h
+++ b/opal/include/opal_stdatomic.h
@@ -42,18 +42,38 @@ enum { OPAL_ATOMIC_LOCK_UNLOCKED = 0,
 
 #    include <stdatomic.h>
 
-typedef atomic_int opal_atomic_int_t;
-typedef atomic_long opal_atomic_long_t;
+typedef struct {
+    _Atomic int v;
+} opal_atomic_int_t;
+typedef struct {
+    _Atomic long v;
+} opal_atomic_long_t;
 
-typedef _Atomic int32_t opal_atomic_int32_t;
-typedef _Atomic uint32_t opal_atomic_uint32_t;
-typedef _Atomic int64_t opal_atomic_int64_t;
-typedef _Atomic uint64_t opal_atomic_uint64_t;
+typedef struct {
+    _Atomic int32_t v;
+} opal_atomic_int32_t;
+typedef struct {
+    _Atomic uint32_t v;
+} opal_atomic_uint32_t;
+typedef struct {
+    _Atomic int64_t v;
+} opal_atomic_int64_t;
+typedef struct {
+    _Atomic uint64_t v;
+} opal_atomic_uint64_t;
 
-typedef _Atomic size_t opal_atomic_size_t;
-typedef _Atomic ssize_t opal_atomic_ssize_t;
-typedef _Atomic intptr_t opal_atomic_intptr_t;
-typedef _Atomic uintptr_t opal_atomic_uintptr_t;
+typedef struct {
+    _Atomic size_t v;
+} opal_atomic_size_t;
+typedef struct {
+    _Atomic ssize_t v;
+} opal_atomic_ssize_t;
+typedef struct {
+    _Atomic intptr_t v;
+} opal_atomic_intptr_t;
+typedef struct {
+    _Atomic uintptr_t v;
+} opal_atomic_uintptr_t;
 
 typedef atomic_flag opal_atomic_lock_t;
 
@@ -68,7 +88,9 @@ typedef atomic_flag opal_atomic_lock_t;
 
 #        if OPAL_USE_C11_ATOMICS && OPAL_HAVE_C11_CSWAP_INT128
 
-typedef _Atomic opal_int128_t opal_atomic_int128_t;
+typedef struct {
+    _Atomic opal_int128_t v;
+} opal_atomic_int128_t;
 
 #        else
 
@@ -76,6 +98,12 @@ typedef volatile opal_int128_t opal_atomic_int128_t __opal_attribute_aligned__(1
 
 #        endif
 
+#    endif
+
+#    if OPAL_USE_C11_ATOMICS
+#        define OPAL_ATOMIC_VAR_INIT(value) { .v = (value) }
+#    else
+#        define OPAL_ATOMIC_VAR_INIT(value) (value)
 #    endif
 
 #endif /* !defined(OPAL_STDATOMIC_H) */

--- a/opal/mca/btl/sm/btl_sm_component.c
+++ b/opal/mca/btl/sm/btl_sm_component.c
@@ -549,7 +549,7 @@ static void mca_btl_sm_progress_endpoints(void)
 
 static int mca_btl_sm_component_progress(void)
 {
-    static opal_atomic_int32_t lock = 0;
+    static opal_atomic_int32_t lock = OPAL_ATOMIC_VAR_INIT(0);
     int count = 0;
 
     if (opal_using_threads()) {
@@ -566,13 +566,13 @@ static int mca_btl_sm_component_progress(void)
     mca_btl_sm_progress_endpoints();
 
     if (SM_FIFO_FREE == mca_btl_sm_component.my_fifo->fifo_head) {
-        lock = 0;
+        opal_atomic_store(&lock, 0);
         return count;
     }
 
     count += mca_btl_sm_poll_fifo();
     opal_atomic_mb();
-    lock = 0;
+    opal_atomic_store(&lock, 0);
 
     return count;
 }

--- a/opal/mca/btl/uct/btl_uct_device_context.h
+++ b/opal/mca/btl/uct/btl_uct_device_context.h
@@ -61,7 +61,7 @@ static inline void mca_btl_uct_context_unlock(mca_btl_uct_device_context_t *cont
 
 static inline int mca_btl_uct_get_context_index(void)
 {
-    static opal_atomic_uint32_t next_uct_index = 0;
+    static opal_atomic_uint32_t next_uct_index = OPAL_ATOMIC_VAR_INIT(0);
     int context_id;
 
 #    if OPAL_C_HAVE__THREAD_LOCAL
@@ -79,7 +79,9 @@ static inline int mca_btl_uct_get_context_index(void)
 #    endif
         /* avoid using atomics in this. i doubt it improves performance to ensure atomicity on the
          * next index in this case. */
-        context_id = next_uct_index++ % mca_btl_uct_component.num_contexts_per_module;
+        context_id = opal_atomic_load(&next_uct_index);
+        opal_atomic_store(&next_uct_index, context_id + 1);
+        context_id %= mca_btl_uct_component.num_contexts_per_module;
 #    if OPAL_C_HAVE__THREAD_LOCAL
     }
 #    endif

--- a/opal/mca/common/ucx/common_ucx_wpool.c
+++ b/opal/mca/common/ucx/common_ucx_wpool.c
@@ -32,8 +32,8 @@ __thread int initialized = 0;
 #endif
 
 bool opal_common_ucx_thread_enabled = false;
-opal_atomic_int64_t opal_common_ucx_ep_counts = 0;
-opal_atomic_int64_t opal_common_ucx_unpacked_rkey_counts = 0;
+opal_atomic_int64_t opal_common_ucx_ep_counts = OPAL_ATOMIC_VAR_INIT(0);
+opal_atomic_int64_t opal_common_ucx_unpacked_rkey_counts = OPAL_ATOMIC_VAR_INIT(0);
 
 static _ctx_record_t *_tlocal_add_ctx_rec(opal_common_ucx_ctx_t *ctx);
 static inline _ctx_record_t *_tlocal_get_ctx_rec(opal_tsd_tracked_key_t tls_key);

--- a/opal/mca/threads/base/wait_sync.c
+++ b/opal/mca/threads/base/wait_sync.c
@@ -47,7 +47,7 @@ void opal_threads_base_wait_sync_global_wakeup_mt(int status)
     opal_mutex_unlock(&wait_sync_lock);
 }
 
-static opal_atomic_int32_t num_thread_in_progress = 0;
+static opal_atomic_int32_t num_thread_in_progress = OPAL_ATOMIC_VAR_INIT(0);
 
 #define WAIT_SYNC_PASS_OWNERSHIP(who)                        \
     do {                                                     \
@@ -97,7 +97,8 @@ int ompi_sync_wait_mt(ompi_wait_sync_t *sync)
      *  - our sync has been triggered.
      */
 check_status:
-    if (sync != opal_threads_base_wait_sync_list && num_thread_in_progress >= opal_max_thread_in_progress) {
+    if (sync != opal_threads_base_wait_sync_list &&
+        opal_atomic_load(&num_thread_in_progress) >= opal_max_thread_in_progress) {
         opal_thread_internal_cond_wait(&sync->condition, &sync->lock);
 
         /**


### PR DESCRIPTION
## Summary
- Wrap C11 `_Atomic` types in structs and provide `OPAL_ATOMIC_VAR_INIT`
- Add `opal_atomic_load/store` macros using relaxed memory order with explicit variants
- Update code to use new atomic API instead of direct loads/stores

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_b_68a39d62d08c8326a82cb77b2a41878c